### PR TITLE
don't throw away the Var in the non-HistAxis Spectrum constructor

### DIFF
--- a/CAFAna/Core/SpectrumConstructors.txx
+++ b/CAFAna/Core/SpectrumConstructors.txx
@@ -25,7 +25,7 @@ namespace ana
                      const SystShifts& shift,
                      const _Var<T>& wei,
                      Spectrum::ESparse sparse)
-    : Spectrum(loader, _HistAxis<_Var<T>>(label, bins), cut, shift, wei, sparse)
+    : Spectrum(loader, _HistAxis<_Var<T>>(label, bins, var), cut, shift, wei, sparse)
   {
   }
 


### PR DESCRIPTION
the non-`HistAxis` version of the `Spectrum` constructor accidentally throws away the `Var` that was passed, so it winds up doing nothing.  fix that