### PR TITLE
Fix thread safety of CAFAnaQuitRequested

### DIFF
--- a/CAFAna/Core/SignalHandlers.cxx
+++ b/CAFAna/Core/SignalHandlers.cxx
@@ -14,20 +14,12 @@
 
 namespace ana
 {
-  std::atomic_flag cafanaQuitRequested = ATOMIC_FLAG_INIT;   // this is initialization to 'false', atomically
+  std::atomic<bool> cafanaQuitRequested(false);
   std::atomic_flag cafanaQuitNow = ATOMIC_FLAG_INIT;
 
   bool CAFAnaQuitRequested()
   {
-    // note that std::atomic_flag::test() doesn't exist until C++20,
-    // so we have to always set the flag, then clear it if it wasn't set.
-    if (cafanaQuitRequested.test_and_set())
-      return true;
-    else
-    {
-      cafanaQuitRequested.clear();
-      return false;
-    }
+    return cafanaQuitRequested;
   }
 
   std::string get_argv0()
@@ -68,7 +60,7 @@ namespace ana
       {
         std::cout << "\nReceived SIGINT or SIGTERM -- trying to shut down nicely." << std::endl;
         std::cout << "Interrupt again with Ctrl-C or 'kill <process id>' to exit immediately." << std::endl;
-        cafanaQuitRequested.test_and_set();
+        cafanaQuitRequested.store(true);
         return;
       }
       _exit(sig+128);


### PR DESCRIPTION
The current implementation of `CAFAnaQuitRequested` makes use of `std::atomic_flag` which doesn't have separate "test" and "set" methods for the underlying flag. Because `CAFAnaQuitRequested` is lock-free, multiple threads can simultaneously enter the method, one can set `std::atomic_flag::test_and_set`, then the second can immediately can find the flag (briefly) set, and erroneously think quit was requested. (This has been a headache for my multithreaded MCMC. Although the chance is low, over hundreds of thousands of steps, this does happen sometimes - Murphy's Law!)

This working example CAF macro illustrates the issue:
```C++

#include <functional>
#include <iostream>

#include <tbb/tbb.h>

#include "CAFAna/Core/SignalHandlers.h"

int TestQuitRequested(void) {
  std::cout << "Starting..." << std::endl;
  const std::function<void(tbb::blocked_range<std::size_t>)> executor = [](const tbb::blocked_range<std::size_t>& t) {
    while ( !ana::CAFAnaQuitRequested() ) {}
    std::cout << "Thread index " << t.begin() << " got quit requested." << std::endl;
  };
  tbb::parallel_for(
    tbb::blocked_range<std::size_t>(0,4,1),
    executor,
    tbb::simple_partitioner()
  );
  std::cout << "Done" << std::endl;
  return 0;
}
```
which has 3/4 threads immediately detect quit without any signal sent. I'm requesting a simple (and cleaner) fix which instead uses `std::atomic<bool>::load` to test, avoiding the issue entirely.